### PR TITLE
Optimize config

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -3,7 +3,7 @@
   description: "This config defines the default Renovate rules that will be used in HiveMQ Product repos.",
   "extends": [
     "config:base",
-    "schedule:earlyMondays"
+    "schedule:weekends"
   ],
   enabledManagers: [
     "gradle",

--- a/default.json5
+++ b/default.json5
@@ -3,7 +3,7 @@
   description: "This config defines the default Renovate rules that will be used in HiveMQ Product repos.",
   "extends": [
     "config:base",
-    "schedule:nonOfficeHours"
+    "schedule:earlyMondays"
   ],
   enabledManagers: [
     "gradle"

--- a/default.json5
+++ b/default.json5
@@ -6,7 +6,8 @@
     "schedule:earlyMondays"
   ],
   enabledManagers: [
-    "gradle"
+    "gradle",
+    "dockerfile"
   ],
   "hostRules": [
     {


### PR DESCRIPTION
* Reduce scheduling to weekly to prevent PR spamming on the workdays
* Add `dockerfile` manager

With daily scheduling we get a lot of PRs during the week, that are partly auto-merged and forces us to rebase our own PRs very frequently. We'd prefer to have more bundled PRs once a week. I've picked `earlyMonday` since it's clearer to me than `weekly` when the scheduling happens (it's on Monday before 4 AM).

The `dockerfile` support should help us with `hivemq4-docker-images`, `hivemq-community-edition` and the operators. We can then replace the `latest`-like `eclipse-temurin:11-jre-jammy` with a specific version, so we can ensure that we build with the latest version (`11-jre-jammy` might be cached on our CI). Renovate will then ensure that we update our Docker images regularly.