### PR TITLE
Fix preset for automergeSchedule

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -4,7 +4,7 @@
   "extends": [
     "config:base",
     "schedule:weekends",
-    "automergeSchedule:automergeNonOfficeHours"
+    "schedule:automergeNonOfficeHours"
   ],
   enabledManagers: [
     "gradle",


### PR DESCRIPTION
https://hivemq.kanbanize.com/ctrl_board/22/cards/18521/details/

> Error type: Cannot find preset's package (automergeSchedule:automergeNonOfficeHours). Note: this is a nested preset so please contact the preset author if you are unable to fix it yourself.

https://github.com/hivemq/hivemq-community-edition/issues/447