### PR TITLE
Include GHA manager using helpers:pinGitHubActionDigests presets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+.idea/
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# MacOS hidden folders
+**/.DS_Store

--- a/default.json5
+++ b/default.json5
@@ -5,12 +5,11 @@
     "config:base",
     "schedule:weekends",
     "schedule:automergeNonOfficeHours",
-    "helpers:pinGitHubActionDigests"
   ],
   enabledManagers: [
     "gradle",
     "dockerfile",
-    "github-actions"
+    "github-actions",
   ],
   "hostRules": [
     {

--- a/default.json5
+++ b/default.json5
@@ -4,11 +4,13 @@
   "extends": [
     "config:base",
     "schedule:weekends",
-    "schedule:automergeNonOfficeHours"
+    "schedule:automergeNonOfficeHours",
+    "helpers:pinGitHubActionDigests"
   ],
   enabledManagers: [
     "gradle",
-    "dockerfile"
+    "dockerfile",
+    "github-actions"
   ],
   "hostRules": [
     {


### PR DESCRIPTION
https://hivemq.kanbanize.com/ctrl_board/22/cards/18997/details/

The `github-actions` manager should help us with the GitHub Actions we already have in some of the repositories (mainly those public). As a good and recommended practice, we should pin the digest for the same by using the `helpers:pinGitHubActionDigests` [preset](https://docs.renovatebot.com/modules/manager/github-actions/#additional-information).

Some testing done on the branch `renovate-playground` for the `helm-charts` repo seems to be fine with this config in the local `renovate.json5` file. See [dashboard](https://github.com/hivemq/helm-charts/issues/129).