### PR TITLE
Add label to renovate PRs

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -30,6 +30,9 @@
     "dependencyDashboardApproval": true
   },
   "pinDigests": true,
+  "labels": [
+    "renovate"
+  ],
   "packageRules": [
     {
       "matchPackagePatterns": [


### PR DESCRIPTION
Renovate doesn't add labels to existing PRs. So for the repos we are setting reminders on, we will need to manually add the `renovate` labels to the PRs.