### PR TITLE
Limit Netty versions to 4.1.x

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -138,6 +138,7 @@
       matchPackageNames: [
         "io.netty:*",
       ],
+      allowedVersions: "<4.2",
       matchUpdateTypes: [
         "minor",
         "patch",


### PR DESCRIPTION
See https://github.com/hivemq/hivemq-enterprise/pull/3386