### PR TITLE
Limit EqualsVerifier to 3.x for LTS branches

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -156,6 +156,17 @@
       matchCurrentVersion: "[8.14.3,)",
       allowedVersions: "<=8.14.3",
     },
+    // EqualsVerifier 4.0 requires Java 17, so we have to limit the version updates for the LTS branches
+    // (see https://github.com/jqno/equalsverifier/blob/main/CHANGELOG.md#40---2025-05-05)
+    {
+      matchBaseBranches: [
+        "/master-4.28/",
+      ],
+      matchPackageNames: [
+        "nl.jqno.equalsverifier:*",
+      ],
+      allowedVersions: "<4",
+    },
     // avoid kafka versions with commercial licenses i.e. versions with 'ce' suffixes
     {
       matchPackageNames: [


### PR DESCRIPTION
See https://github.com/jqno/equalsverifier/blob/main/CHANGELOG.md#40---2025-05-05

```
07:14:16  > Task :hivemq-kafka-extension:compileTestJava
07:14:16  /opt/jenkins/workspace/master-4.28-major-equalsverifier/hivemq-kafka-extension/src/test/java/com/hivemq/extensions/kafka/configuration/hotreload/MqttTopicMqttToKafkaMigrateActionTest.java:3: error: cannot access EqualsVerifier
07:14:16  import nl.jqno.equalsverifier.EqualsVerifier;
07:14:16                               ^
07:14:16    bad class file: /home/jenkins/.gradle/caches/modules-2/files-2.1/nl.jqno.equalsverifier/equalsverifier/4.0.1/d5601281ffa83d89537624e73f09ac670f78faab/equalsverifier-4.0.1.jar(/nl/jqno/equalsverifier/EqualsVerifier.class)
07:14:16      class file has wrong version 61.0, should be 55.0
07:14:16      Please remove or make sure it appears in the correct subdirectory of the classpath.
```
https://jenkins.cicd.pd.hmq.dev/job/HiveMQ4/job/hivemq4-composite/job/renovate%252Fhivemq-kafka-extension%252Fmaster-4.28-major-equalsverifier/1/execution/node/471/log/