### PR TITLE
Temporarily disable NPM updates

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -11,7 +11,7 @@
     'gradle',
     'dockerfile',
     'github-actions',
-    'npm',
+//    'npm',
     'regex',
   ],
   hostRules: [
@@ -25,11 +25,11 @@
       username: 'hivemq-jenkins',
       token: '{{ secrets.GITHUB_TOKEN_HIVEMQ_JENKINS }}',
     },
-    {
-      matchHost: 'npm.pkg.github.com',
-      hostType: 'npm',
-      token: '{{ secrets.GITHUB_TOKEN_HIVEMQ_JENKINS }}',
-    },
+//    {
+//      matchHost: 'npm.pkg.github.com',
+//      hostType: 'npm',
+//      token: '{{ secrets.GITHUB_TOKEN_HIVEMQ_JENKINS }}',
+//    },
   ],
   major: {
     dependencyDashboardApproval: true,
@@ -87,29 +87,29 @@
       groupSlug: 'all-patch',
       automerge: true,
     },
-    {
-      matchManagers: [
-        'npm',
-      ],
-      matchUpdateTypes: [
-        'minor',
-      ],
-      matchCurrentVersion: '!/^0/',
-      groupName: 'all minor npm dependencies',
-      groupSlug: 'all-minor-npm',
-    },
-    {
-      matchManagers: [
-        'npm',
-      ],
-      matchUpdateTypes: [
-        'patch',
-      ],
-      matchCurrentVersion: '!/^0/',
-      groupName: 'all patch npm dependencies',
-      groupSlug: 'all-patch-npm',
-      automerge: true,
-    },
+//    {
+//      matchManagers: [
+//        'npm',
+//      ],
+//      matchUpdateTypes: [
+//        'minor',
+//      ],
+//      matchCurrentVersion: '!/^0/',
+//      groupName: 'all minor npm dependencies',
+//      groupSlug: 'all-minor-npm',
+//    },
+//    {
+//      matchManagers: [
+//        'npm',
+//      ],
+//      matchUpdateTypes: [
+//        'patch',
+//      ],
+//      matchCurrentVersion: '!/^0/',
+//      groupName: 'all patch npm dependencies',
+//      groupSlug: 'all-patch-npm',
+//      automerge: true,
+//    },
     {
       matchCurrentVersion: '/^0/',
       dependencyDashboardApproval: true,


### PR DESCRIPTION
We currently have a ton of pending patch, minor and major updates for the frontend dependencies that need to be kept in sync between `hivemq-enterprise`, `hivemq-platform-sdk` and `hivemq-kafka-extension`.

To not risk the releases next week we would like to temporarily disable the NPM manager, to ensure that no frontend dependency updates are attempted over the weekend.

After the pulse release we can enable this again and work on the remaining updates and a better update strategy for frontend dependencies.