### PR TITLE
Automerge OCI digest-only updates

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -229,6 +229,21 @@
       enabled: false
     },
     {
+      description: 'OCI digest-only updates',
+      matchManagers: [
+        'regex',
+      ],
+      matchFileNames: [
+        '**/oci.versions.toml',
+      ],
+      matchUpdateTypes: [
+        'digest',
+      ],
+      groupName: 'all OCI digest dependencies',
+      groupSlug: 'all-oci-digest',
+      automerge: true,
+    },
+    {
       description: 'GitHub Actions major',
       matchManagers: [
         'github-actions'


### PR DESCRIPTION
## Summary
- Adds a package rule to automerge digest-only updates from `oci.versions.toml` files
- Scoped to the `regex` manager and `**/oci.versions.toml` file pattern
- Groups all OCI digest updates into a single PR per repo

## Context
Part of INT-210. Digest-only changes (same tag, rebuilt upstream image) are low-risk and don't need manual approval.