### PR TITLE
Limit Eclipse Temurin Docker image to Java 25

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -244,6 +244,13 @@
       automerge: true,
     },
     {
+      description: 'Eclipse Temurin 26 is not LTS, limit major updates to Java 25',
+      matchPackageNames: [
+        'library/eclipse-temurin',
+      ],
+      allowedVersions: '<26',
+    },
+    {
       description: 'GitHub Actions major',
       matchManagers: [
         'github-actions'


### PR DESCRIPTION
## Summary
- Adds a packageRule that caps `library/eclipse-temurin` at major version 25 via `allowedVersions: '<26'`.
- Java 26 is not an LTS release, so we want to avoid Renovate auto-proposing the major bump for repos that pin Temurin in `oci.versions.toml`.
- Repos currently on an older Temurin major (e.g. 21) keep all upgrade paths up to and including 25 — only 26+ is filtered out.