### PR TITLE
Skip Kafka 7.9.6 / 7.9.7 patches and fix allowedVersions collision

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -199,11 +199,18 @@
       allowedVersions: '<=8.14.3'
     },
     {
-      description: 'avoid Kafka versions with commercial licenses, i.e. versions with ce suffixes',
+      description: 'avoid Kafka versions with commercial licenses (ce suffix) and skip the 7.9.6 / 7.9.7 patch versions',
       matchPackageNames: [
         'org.apache.kafka:*'
       ],
-      allowedVersions: '!/ce$/'
+      allowedVersions: '!/(ce$|^7\\.9\\.(6|7)(-.*)?$)/'
+    },
+    {
+      description: 'skip the Confluent kafka-avro-serializer 7.9.6 / 7.9.7 patch versions',
+      matchPackageNames: [
+        'io.confluent:kafka-avro-serializer'
+      ],
+      allowedVersions: '!/^7\\.9\\.(6|7)(-.*)?$/'
     },
     {
       description: 'avoid JCTools versions with ea suffix (see https://github.com/JCTools/JCTools/issues/360)',

--- a/default.json5
+++ b/default.json5
@@ -210,7 +210,7 @@
       matchPackageNames: [
         'io.confluent:kafka-avro-serializer'
       ],
-      allowedVersions: '!/^7\\.9\\.(6|7)(-.*)?$/'
+      allowedVersions: '!/^7\\.9\\.(6|7)$/'
     },
     {
       description: 'avoid JCTools versions with ea suffix (see https://github.com/JCTools/JCTools/issues/360)',


### PR DESCRIPTION
## Summary

Merges the `7.9.6` / `7.9.7` patch-version exclusion into the existing `'!/ce$/'` rule for `org.apache.kafka:*`, and adds a separate rule for `io.confluent:kafka-avro-serializer`.

Previously the hivemq-kafka-extension repo had its own `allowedVersions: '!/^7\.9\.(6|7)(-.*)?$/'` rule for `org.apache.kafka:kafka-clients`. Since `allowedVersions` is a single-value field, repo-level rules **override** the base rule's `'!/ce$/'` filter when both match the same package. This let `7.9.5-ce` slip through in [hivemq/hivemq-kafka-extension#1383](https://github.com/hivemq/hivemq-kafka-extension/pull/1383).

Combining both constraints into a single rule (`!/(ce$|^7\.9\.(6|7)(-.*)?$)/`) keeps both filters active for `org.apache.kafka:*` across all consumers of this config.

The companion change removing the now-redundant repo-level rule: hivemq/hivemq-kafka-extension PR.