### PR TITLE
Group Gradle Enterprise plugins instead of disabling updates

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -227,13 +227,14 @@
       enabled: false
     },
     {
-      description: 'avoid updating Gradle Enterprise plugins as these need to be updated in sync',
+      description: 'group Gradle Enterprise plugins separately as these need to be updated in sync',
       matchPackageNames: [
         'com.gradle.develocity:com.gradle.develocity.gradle.plugin',
         'com.gradle.enterprise:com.gradle.enterprise.gradle.plugin',
         'com.gradle.common-custom-user-data-gradle-plugin:com.gradle.common-custom-user-data-gradle-plugin.gradle.plugin'
       ],
-      enabled: false
+      groupName: 'Gradle Enterprise plugins',
+      groupSlug: 'gradle-enterprise-plugins'
     },
     {
       description: 'OCI digest-only updates',


### PR DESCRIPTION
## What

The Develocity, Gradle Enterprise, and common-custom-user-data plugins were pinned with `enabled: false` because they must be bumped in sync. This swaps that for a dedicated group so their updates get surfaced without mixing into the general minor/patch groups.

## Why

`enabled: false` hid the updates entirely, so bumps were purely manual. Grouping keeps them together (still easy to review as a sync-bump) while making Renovate open a PR when new versions land.

## Note

Renovate splits by update type, so a minor bump of one plugin and a patch of another can still open two PRs. If strict single-PR sync is required, add `separateMinorPatch: false` to this rule.