### PR TITLE
chore: Update Netty guard to only block 4.2 for current LTS version.

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -154,21 +154,14 @@
       enabled: false
     },
     {
-      description: 'Netty 4.2 introduces breaking changes - we have to fix the extension classloader before we can update',
+      description: 'Netty - Limit LTS 4.28 to well known version',
+      matchBaseBranches: [
+        'master-4.28'
+      ],
       matchPackageNames: [
         'io.netty:*'
       ],
       allowedVersions: '<4.2',
-      groupName: 'non-major netty dependencies',
-      groupSlug: 'non-major-netty'
-    },
-    {
-      description: 'Allow Netty updates for projects that have already migrated to version >= 4.2',
-      matchPackageNames: [
-        'io.netty:*'
-      ],
-      matchCurrentVersion: '[4.2.0.Final,)',
-      allowedVersions: '/^4\\.[0-9]+\\.[0-9]+\\.Final$/',
       groupName: 'non-major netty dependencies',
       groupSlug: 'non-major-netty'
     },


### PR DESCRIPTION
https://linear.app/hivemq/issue/BCD-204/netty-update-420