### PR TITLE
PLT-1261: fix: apply the Temurin LTS limit in any registry

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -253,8 +253,11 @@
     },
     {
       description: 'Eclipse Temurin 26 is not LTS, limit major updates to Java 25',
+      // Matches the image in any registry: it is consumed from Docker Hub as library/eclipse-temurin, and from
+      // ECR Public as public.ecr.aws/<alias>/base-images/eclipse-temurin (PLT-1261). The ECR registry alias is
+      // still provisional, so match on the image name rather than on any one path.
       matchPackageNames: [
-        'library/eclipse-temurin',
+        '**/eclipse-temurin',
       ],
       allowedVersions: '<26',
     },


### PR DESCRIPTION
## What

Widens the Eclipse Temurin LTS guard from `library/eclipse-temurin` to `**/eclipse-temurin`, so it applies to the image in any registry.

## Why

PLT-1261 migrates consumers off the Docker Hub base image and onto the security-patched one published to ECR Public (PLT-941 / PLT-1402). The same image is named differently there:

| | Package name |
|---|---|
| Docker Hub (today) | `library/eclipse-temurin` |
| ECR Public (after migration) | `public.ecr.aws/y7j2u9c5/base-images/eclipse-temurin` |

The `oci.versions.toml` custom manager captures `depName` verbatim from the `image` field, so once a consumer migrates, its dependency name changes and **stops matching this rule**. The failure is silent: nothing breaks, the guard just quietly stops applying and Java 26 major updates start flowing — exactly what the rule exists to prevent.

Matching the image name rather than one full path also survives the pending ECR alias change: `y7j2u9c5` is the AWS-assigned default, and a custom alias is awaiting approval, which would otherwise force another edit here.

## Is the wildcard supported?

Yes. Per [string pattern matching](https://docs.renovatebot.com/string-pattern-matching/): *"If the string provided is not a regex pattern then it will be treated as a glob pattern and parsed using the `minimatch` library."* A leading `**` crosses `/` separators, which is what makes one pattern cover both a two-segment Docker Hub name and a four-segment ECR Public path.

Verified against minimatch directly. To confirm that is really the engine and not an assumption, the docs' own examples were replicated first — `abc*`, `abc**/*`, `abc**/**` — and all 11 documented cases agree.

| Package name | Old rule | New rule | |
|---|---|---|---|
| `library/eclipse-temurin` | ✅ | ✅ | Docker Hub — the 7 catalog consumers today |
| `public.ecr.aws/y7j2u9c5/base-images/eclipse-temurin` | ❌ | ✅ | ECR Public, current alias — the point of this PR |
| `public.ecr.aws/hivemq/base-images/eclipse-temurin` | ❌ | ✅ | ECR Public, pending custom alias |
| `eclipse-temurin` | ❌ | ✅ | bare name — see below |
| `library/eclipse-temurin-jre` | ❌ | ❌ | does not over-match a different image |
| `rancher/k3s` | ❌ | ❌ | does not over-match unrelated images |

`renovate-config-validator` reports no new findings: the one pre-existing warning (`packageRules[14]` / `matchBaseBranches`) is byte-for-byte identical on unmodified `main`.

## One intentional behaviour change, beyond the migration

`**` matches zero or more segments, so `**/eclipse-temurin` also matches the **bare** name `eclipse-temurin` — which the old rule did not. That is not hypothetical: `hivemq4-docker-images/hivemq4/base-image/Dockerfile` has `FROM eclipse-temurin:21.0.5_11-jre-jammy@…`, which the `dockerfile` manager reports under the short name, so it was never covered by the `library/`-prefixed rule.

This is a gap being closed rather than a regression — it is the same image, and the "26 is not LTS" reasoning applies however it is referenced. It is inert today (that Dockerfile is on 21), and takes effect only if a Java 26 image is published. Flagging it because it means this PR is not purely a no-op until the ECR migration; if you would rather keep the scope strictly to the migration, say so and I will enumerate the two registry paths explicitly instead.

## Notes

Otherwise safe to merge ahead of the migration — the pattern is a superset of the current one, so the 7 catalog consumers behave exactly as they do today until they actually move.