### PR TITLE
PLT-1579: docs: point the Temurin comment at the current ECR path

### DIFF
--- a/default.json5
+++ b/default.json5
@@ -254,8 +254,9 @@
     {
       description: 'Eclipse Temurin 26 is not LTS, limit major updates to Java 25',
       // Matches the image in any registry: it is consumed from Docker Hub as library/eclipse-temurin, and from
-      // ECR Public as public.ecr.aws/<alias>/base-images/eclipse-temurin (PLT-1261). The ECR registry alias is
-      // still provisional, so match on the image name rather than on any one path.
+      // ECR Public as public.ecr.aws/hivemq/library/eclipse-temurin (PLT-1261, PLT-1579). Matching on the image
+      // name rather than any one path is what kept this rule working across the base-images/ -> library/ rename
+      // and the y7j2u9c5 -> hivemq alias change, so keep it that way.
       matchPackageNames: [
         '**/eclipse-temurin',
       ],


### PR DESCRIPTION
## What

Comment-only. Updates the ECR Public path in the Temurin LTS rule's comment from `public.ecr.aws/<alias>/base-images/eclipse-temurin` to `public.ecr.aws/hivemq/library/eclipse-temurin`.

## Why

Both halves of the old description have settled since it was written:

- the "still provisional" registry alias is now the approved `hivemq` (replacing `y7j2u9c5`);
- `base-images/` was renamed to `library/` (PLT-1579; hivemq/hivemq-ecr#45 and hivemq/images#15, merged and applied).

## No behaviour change

The rule matches `**/eclipse-temurin`, so it kept working across both the rename and the alias change without any edit. The comment now records that as the reason to keep matching on the image name rather than a path — the original text framed it as a temporary hedge against a provisional alias, which undersells it.

Verified the diff touches only `//` comment lines, so JSON5 parsing is unaffected. There is no CI in this repo.
